### PR TITLE
1-kct Add Bus method to Manager

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -35,6 +35,11 @@ func NewManager(bufSize int) *Manager {
 	}
 }
 
+// Bus returns internal bus instance.
+func (m *Manager) Bus() *Bus {
+	return m.bus
+}
+
 // Listen starts a channels listeners.
 func (m *Manager) Listen() {
 	handlersCount := len(m.handlers)


### PR DESCRIPTION
Bus method provides access to the internal Bus instance, which is used by delivers.

Closes #1 